### PR TITLE
Fix git worktree support and SSH URL handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,8 @@ func run() error {
 	}
 
 	r, err := git.PlainOpenWithOptions(targetPath, &git.PlainOpenOptions{
-		DetectDotGit: true,
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
 	})
 
 	if err != nil {
@@ -69,6 +70,16 @@ func run() error {
 	}
 
 	u := remote.Config().URLs[0]
+
+	// Convert SSH URL to HTTPS URL
+	if strings.HasPrefix(u, "git@") {
+		// git@github.com:user/repo.git -> https://github.com/user/repo
+		u = strings.Replace(u, "git@", "https://", 1)
+		u = strings.Replace(u, ".com:", ".com/", 1)
+		u = strings.Replace(u, ".org:", ".org/", 1)
+		u = strings.Replace(u, ".net:", ".net/", 1)
+		u = strings.TrimSuffix(u, ".git")
+	}
 
 	err = browser.OpenURL(u)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Added `EnableDotGitCommonDir` option to properly support git worktrees
- Implemented SSH to HTTPS URL conversion for browser compatibility

## Problem
The gito CLI was not working correctly in git worktree directories. Additionally, SSH URLs (git@github.com:user/repo.git) could not be opened directly in browsers.

## Solution
1. **Git Worktree Support**: Added the `EnableDotGitCommonDir: true` option to `git.PlainOpenOptions`. This enables go-git to correctly handle git worktrees, which use a .git file that references a common .git directory.

2. **SSH URL Conversion**: Implemented logic to convert SSH-style git URLs to HTTPS format that browsers can open:
   - Converts `git@github.com:user/repo.git` to `https://github.com/user/repo`
   - Handles common git hosting domains (.com, .org, .net)
   - Removes the `.git` suffix for cleaner browser URLs

## Testing
- Tested with git worktree directories
- Verified SSH URL conversion works correctly
- Confirmed browser opens the correct repository page

## Impact
This fix ensures the gito CLI works reliably in all git repository configurations, including worktrees, and handles both HTTPS and SSH remote URLs properly.