### PR TITLE
Add gito binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Built binary
+gito


### PR DESCRIPTION
## Summary
Added the `gito` binary to `.gitignore` to exclude it from version control.

## Motivation
The compiled binary file `gito` should not be tracked in the repository as it is a build artifact that can be generated from the source code.

## Changes
- Added `gito` entry to `.gitignore` file

## Impact
This keeps the repository clean by excluding built binaries from version control, following Go project best practices.